### PR TITLE
Refactor to be consistent with mina-sidekiq

### DIFF
--- a/lib/mina/rsync/version.rb
+++ b/lib/mina/rsync/version.rb
@@ -1,5 +1,0 @@
-module Mina
-  module Rsync
-    VERSION = "1.1.0"
-  end
-end

--- a/lib/mina_rsync.rb
+++ b/lib/mina_rsync.rb
@@ -1,0 +1,4 @@
+require 'mina_rsync/version'
+
+module MinaRsync
+end

--- a/lib/mina_rsync/tasks.rb
+++ b/lib/mina_rsync/tasks.rb
@@ -1,4 +1,6 @@
-require File.expand_path("../rsync/version", __FILE__)
+require 'mina/bundler'
+require 'mina/rails'
+#require File.expand_path("../rsync/version", __FILE__)
 
 # NOTE: Please don't depend on tasks without a description (`desc`) as they
 # might change between minor or patch version releases. They make up the

--- a/lib/mina_rsync/version.rb
+++ b/lib/mina_rsync/version.rb
@@ -1,0 +1,5 @@
+module MinaRsync
+  def self.version
+    "1.1.0"
+  end
+end

--- a/mina-rsync.gemspec
+++ b/mina-rsync.gemspec
@@ -1,9 +1,9 @@
-require File.expand_path("../lib/mina/rsync/version", __FILE__)
+require "./lib/mina_rsync/version.rb"
 
 Gem::Specification.new do |gem|
   gem.name = "mina-rsync"
-  gem.version = Mina::Rsync::VERSION
-  gem.homepage = "https://github.com/moll/mina-rsync"
+  gem.version = MinaRsync.version
+  gem.homepage = "https://github.com/andywatts/mina-rsync"
   gem.summary = <<-end.strip.gsub(/\s*\n\s*/, " ")
     Deploy with Rsync from any local (or remote) repository.
   end

--- a/mina-rsync.gemspec
+++ b/mina-rsync.gemspec
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "./lib/mina_rsync/version.rb"
 
 Gem::Specification.new do |gem|


### PR DESCRIPTION
Fixes a bug: undefined method `set_default' for main:Object (NoMethodError) when starting a rake task. See also https://github.com/Mic92/mina-sidekiq/issues/2. Pulled this fix from another fork (thanks @andywatts!)
