### PR TITLE
Fix breaking changes for mina 1.0

### DIFF
--- a/lib/mina/rsync.rb
+++ b/lib/mina/rsync.rb
@@ -72,7 +72,7 @@ namespace :rsync do
 
   task :build do
     command %(echo "-> Copying from cache directory to build path")
-    command! %(#{fetch(:rsync_copy)} "#{rsync_cache.call}/" ".")
+    command %(#{fetch(:rsync_copy)} "#{rsync_cache.call}/" ".")
   end
 
   desc "Stage, rsync and copy to the build path."

--- a/lib/mina/rsync.rb
+++ b/lib/mina/rsync.rb
@@ -19,8 +19,8 @@ set :rsync_cache, "shared/deploy"
 
 run = lambda do |*cmd|
   cmd = cmd[0] if cmd[0].is_a?(Array)
-  print_command cmd.join(" ") if simulate_mode? || verbose_mode?
-  Kernel.system *cmd unless simulate_mode?
+  print_command cmd.join(" ") if fetch(:simulate) || fetch(:verbose)
+  Kernel.system *cmd unless fetch(:simulate)
 end
 
 rsync_cache = lambda do
@@ -66,7 +66,7 @@ namespace :rsync do
 
     # Prefix the Git "HEAD is now at" message, but only if verbose is unset,
     # because then the #print_command called by #run prints its own prefix.
-    print "Git checkout: " unless simulate_mode? || verbose_mode?
+    print "Git checkout: " unless fetch(:simulate) || fetch(:verbose)
     run.call git + %W[reset --hard origin/#{fetch(:branch)}]
   end
 

--- a/lib/mina/rsync.rb
+++ b/lib/mina/rsync.rb
@@ -71,8 +71,8 @@ namespace :rsync do
   end
 
   task :build do
-    queue %(echo "-> Copying from cache directory to build path")
-    queue! %(#{fetch(:rsync_copy)} "#{rsync_cache.call}/" ".")
+    command %(echo "-> Copying from cache directory to build path")
+    command! %(#{fetch(:rsync_copy)} "#{rsync_cache.call}/" ".")
   end
 
   desc "Stage, rsync and copy to the build path."

--- a/lib/mina/rsync.rb
+++ b/lib/mina/rsync.rb
@@ -5,17 +5,17 @@ require File.expand_path("../rsync/version", __FILE__)
 # private API and internals of Mina::Rsync. If you think something should be
 # public for extending and hooking, please let me know!
 
-set_default :repository, "."
-set_default :branch, "master"
-set_default :rsync_options, []
-set_default :rsync_copy, "rsync --archive --acls --xattrs"
+set :repository, "."
+set :branch, "master"
+set :rsync_options, []
+set :rsync_copy, "rsync --archive --acls --xattrs"
 
 # Stage is used on your local machine for rsyncing from.
-set_default :rsync_stage, "tmp/deploy"
+set :rsync_stage, "tmp/deploy"
 
 # Cache is used on the server to copy files to from to the release directory.
 # Saves you rsyncing your whole app folder each time.
-set_default :rsync_cache, "shared/deploy"
+set :rsync_cache, "shared/deploy"
 
 run = lambda do |*cmd|
   cmd = cmd[0] if cmd[0].is_a?(Array)


### PR DESCRIPTION
Many parts of the code base contained code that did not work with mina '~> 1.0'.  The contributors for mina outlined the breaking changes here:

https://github.com/mina-deploy/mina/blob/master/docs/migrating.md
